### PR TITLE
fix for missing fn paren warnings in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,16 @@ defmodule ColorUtils.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :color_utils,
-     version: "0.2.0",
-     elixir: "~> 1.0",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     package: package,
-     description: description,
-     deps: deps]
+    [
+      app: :color_utils,
+      version: "0.2.1",
+      elixir: "~> 1.0",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      package: package(),
+      description: description(),
+      deps: deps(),
+    ]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Simple fix to suppress missing warnings re: missing parens in mix.exs:
```
warning: variable "package" does not exist and is being expanded to "package()", 
please use parentheses to remove the ambiguity or change the variable name
  /your-app/deps/color_utils/mix.exs:10

warning: variable "description" does not exist and is being expanded to "description()", 
please use parentheses to remove the ambiguity or change the variable name
  /your-app/deps/color_utils/mix.exs:11

warning: variable "deps" does not exist and is being expanded to "deps()", 
please use parentheses to remove the ambiguity or change the variable name
  /your-app/deps/color_utils/mix.exs:12
```